### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/prodas/47be2f77-77d5-4a92-9e60-f28e21197a89/55485471-e797-46fc-aed8-5f4f1216e21e/_apis/work/boardbadge/ecce4b8f-d172-445f-ad39-41fbdc2e33c1)](https://dev.azure.com/prodas/47be2f77-77d5-4a92-9e60-f28e21197a89/_boards/board/t/55485471-e797-46fc-aed8-5f4f1216e21e/Microsoft.RequirementCategory)
 # CirculoDeSangre
 
 Documentacion asociada al proyecto: [DocumentacionRodasPablo.pdf](https://github.com/prodass/CirculoDeSangre/files/8541274/DocumentacionRodasPablo.pdf)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/prodas/47be2f77-77d5-4a92-9e60-f28e21197a89/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.